### PR TITLE
Add codemirror-colorpicker manual site

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,8 @@
 
 ## Sites
 
+- [codemirror-colorpicker manual](https://easylogic.github.io/codemirror-colorpicker/)
+
 ### Official Vue Projects
 
 - [vue-cli](https://cli.vuejs.org)

--- a/Readme.md
+++ b/Readme.md
@@ -22,8 +22,6 @@
 
 ## Sites
 
-- [codemirror-colorpicker manual](https://easylogic.github.io/codemirror-colorpicker/)
-
 ### Official Vue Projects
 
 - [vue-cli](https://cli.vuejs.org)
@@ -42,3 +40,4 @@
 - [vuesax](https://lusaxweb.github.io/vuesax) - Vuesax Frontend Vue Components
 - [vue-showdown](https://vue-showdown.js.org) - Use showdown.js in Vue
 - [vssue](https://vssue.js.org) - A Vue-powered Issue-based Comment Plugin
+- [codemirror-colorpicker](https://easylogic.github.io/codemirror-colorpicker/) - Colorpicker manual site


### PR DESCRIPTION
This is colorpicker manual site made by vuepress.